### PR TITLE
fix(install): Fixed "default_install" function scope

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,6 @@ default_install() {
     bash "$SCRIPT_DIR/module/fixfilecontext.sh" || {
       echo "Ошибка: не удалось запустить fixfilecontext.sh"
     }
-  }
   fi
 
   echo "Запуск install_easy.sh..."


### PR DESCRIPTION
Скрипт установки падал на 47-ой строке из-за некорректной области видимости. ( См. [#cff0fe0](https://github.com/kartavkun/zapret-discord-youtube/commit/cff0fe04e64486d8051a9b2b0e4f3957a39258ae#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR47) ) 