### PR TITLE
Update setup.sh (add parametr --no-check-certificate)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -32,7 +32,7 @@ ZAPRET_VERSION="v70.3"
 
 # Закачка последнего релиза bol-van/zapret
 echo "Скачивание последнего релиза zapret..."
-if ! wget -O "$HOME/tmp/zapret-$ZAPRET_VERSION.tar.gz" "https://github.com/bol-van/zapret/releases/download/$ZAPRET_VERSION/zapret-$ZAPRET_VERSION.tar.gz"; then
+if ! wget -O "$HOME/tmp/zapret-$ZAPRET_VERSION.tar.gz" "https://github.com/bol-van/zapret/releases/download/$ZAPRET_VERSION/zapret-$ZAPRET_VERSION.tar.gz" --no-check-certificate; then
   echo "Ошибка: не удалось скачать zapret."
   exit 1
 fi


### PR DESCRIPTION
norton@iMacPro-Anton /opt % bash <(curl -s https://raw.githubusercontent.com/kartavkun/zapret-discord-youtube/macos/setup.sh)
Обнаружен brew, устанавливаем wget...
Warning: wget 1.25.0 is already installed and up-to-date.
To reinstall 1.25.0, run:
  brew reinstall wget
Warning: git 2.51.1 is already installed and up-to-date.
To reinstall 2.51.1, run:
  brew reinstall git
wget успешно установлен!
Password:
cp: /opt/zapret: No such file or directory
Скачивание последнего релиза zapret...
--2025-10-27 11:34:36--  https://github.com/bol-van/zapret/releases/download/v70.3/zapret-v70.3.tar.gz
Распознаётся github.com (github.com)… 140.82.121.3
Подключение к github.com (github.com)|140.82.121.3|:443... соединение установлено.
ОШИБКА: невозможно проверить сертификат github.com, выпущенный «CN=Sectigo ECC Domain Validation Secure Server CA,O=Sectigo Limited,L=Salford,ST=Greater Manchester,C=GB»:
  Невозможно локально проверить подлинность запрашивающего.
Для небезопасного подключения к github.com используйте параметр «--no-check-certificate».
Ошибка: не удалось скачать zapret.
norton@iMacPro-Anton /opt % 
