### PR TITLE
добавление в исключения нужных для nixos доменов

### DIFF
--- a/hostlists/list-exclude.txt
+++ b/hostlists/list-exclude.txt
@@ -24,3 +24,8 @@ akamaitechnologies.com
 2ip.ru
 yandex.ru
 boosty.to
+netlify.app
+netlify.com
+fastly.net
+fastly.com
+nixos.org

--- a/hostlists/list-general.txt
+++ b/hostlists/list-general.txt
@@ -45,8 +45,3 @@ betterttv.net
 7tv.app
 7tv.io
 localizeapi.com
-netlify.app
-netlify.com
-fastly.net
-fastly.com
-nixos.org


### PR DESCRIPTION
без этого cache.nixos.org и search.nixos.org таймаутят, во всяком случае, у меня