### PR TITLE
Добавленение general (SIMPLE FAKE ALT3)

### DIFF
--- a/general (SIMPLE FAKE ALT3)
+++ b/general (SIMPLE FAKE ALT3)
@@ -1,0 +1,169 @@
+# general (SIMPLE FAKE ALT3)
+
+# this file is included from init scripts
+# change values here
+
+# can help in case /tmp has not enough space
+#TMPDIR=/opt/zapret/tmp
+
+# redefine user for zapret daemons. required on Keenetic
+#WS_USER=nobody
+
+# override firewall type : iptables,nftables,ipfw
+FWTYPE=iptables
+# nftables only : set this to 0 to use pre-nat mode. default is post-nat.
+# pre-nat mode disables some bypass techniques for forwarded traffic but allows to see client IP addresses in debug log
+#POSTNAT=0
+
+# options for ipsets
+# maximum number of elements in sets. also used for nft sets
+SET_MAXELEM=522288
+# too low hashsize can cause memory allocation errors on low RAM systems , even if RAM is enough
+# too large hashsize will waste lots of RAM
+IPSET_OPT="hashsize 262144 maxelem $SET_MAXELEM"
+# dynamically generate additional ip. $1 = ipset/nfset/table name
+#IPSET_HOOK="/etc/zapret.ipset.hook"
+
+# options for ip2net. "-4" or "-6" auto added by ipset create script
+IP2NET_OPT4="--prefix-length=22-30 --v4-threshold=3/4"
+IP2NET_OPT6="--prefix-length=56-64 --v6-threshold=5"
+# options for auto hostlist
+AUTOHOSTLIST_RETRANS_THRESHOLD=3
+AUTOHOSTLIST_FAIL_THRESHOLD=3
+AUTOHOSTLIST_FAIL_TIME=60
+# 1 = debug autohostlist positives to ipset/zapret-hosts-auto-debug.log
+AUTOHOSTLIST_DEBUGLOG=0
+
+# number of parallel threads for domain list resolves
+MDIG_THREADS=30
+
+# ipset/*.sh can compress large lists
+GZIP_LISTS=1
+# command to reload ip/host lists after update
+# comment or leave empty for auto backend selection : ipset or ipfw if present
+# on BSD systems with PF no auto reloading happens. you must provide your own command
+# set to "-" to disable reload
+#LISTS_RELOAD="pfctl -f /etc/pf.conf"
+
+# mark bit used by nfqws to prevent loop
+DESYNC_MARK=0x40000000
+DESYNC_MARK_POSTNAT=0x20000000
+
+TPWS_SOCKS_ENABLE=0
+# tpws socks listens on this port on localhost and LAN interfaces
+TPPORT_SOCKS=987
+# use <HOSTLIST> and <HOSTLIST_NOAUTO> placeholders to engage standard hostlists and autohostlist in ipset dir
+# hostlist markers are replaced to empty string if MODE_FILTER does not satisfy
+# <HOSTLIST_NOAUTO> appends ipset/zapret-hosts-auto.txt as normal list
+TPWS_SOCKS_OPT="
+--filter-tcp=80 --methodeol <HOSTLIST> --new
+--filter-tcp=443 --split-pos=1,midsld --disorder <HOSTLIST>
+"
+
+TPWS_ENABLE=0
+TPWS_PORTS=80,443
+# use <HOSTLIST> and <HOSTLIST_NOAUTO> placeholders to engage standard hostlists and autohostlist in ipset dir
+# hostlist markers are replaced to empty string if MODE_FILTER does not satisfy
+# <HOSTLIST_NOAUTO> appends ipset/zapret-hosts-auto.txt as normal list
+TPWS_OPT="
+--filter-tcp=80 --methodeol <HOSTLIST> --new
+--filter-tcp=443 --split-pos=1,midsld --disorder <HOSTLIST>
+"
+
+NFQWS_ENABLE=1
+# redirect outgoing traffic with connbytes limiter applied in both directions.
+NFQWS_PORTS_TCP=80,443
+NFQWS_PORTS_UDP=443,50000-65535
+
+# Game filter ports - set by game filter toggle
+# Modes: all (TCP+UDP), tcp (TCP only), udp (UDP only), disabled (12)
+GAME_FILTER_TCP="12"
+GAME_FILTER_UDP="12"
+
+if [ -f "/opt/zapret/hostlists/.game_filter.enabled" ]; then
+    GAME_FILTER_MODE=$(cat "/opt/zapret/hostlists/.game_filter.enabled" 2>/dev/null)
+    case "$GAME_FILTER_MODE" in
+        tcp)
+            GAME_FILTER_TCP="1024-65535"
+            GAME_FILTER_UDP="12"
+            ;;
+        udp)
+            GAME_FILTER_TCP="12"
+            GAME_FILTER_UDP="1024-65535"
+            ;;
+        all|*)
+            GAME_FILTER_TCP="1024-65535"
+            GAME_FILTER_UDP="1024-65535"
+            ;;
+    esac
+fi
+
+# PKT_OUT means connbytes dir original
+# PKT_IN means connbytes dir reply
+# this is --dpi-desync-cutoff=nX kernel mode implementation for linux. it saves a lot of CPU.
+NFQWS_TCP_PKT_OUT=$((6+$AUTOHOSTLIST_RETRANS_THRESHOLD))
+NFQWS_TCP_PKT_IN=3
+NFQWS_UDP_PKT_OUT=$((6+$AUTOHOSTLIST_RETRANS_THRESHOLD))
+NFQWS_UDP_PKT_IN=0
+# redirect outgoing traffic without connbytes limiter and incoming with connbytes limiter
+# normally it's needed only for stateless DPI that matches every packet in a single TCP session
+# typical example are plain HTTP keep alives
+# this mode can be very CPU consuming. enable with care !
+#NFQWS_PORTS_TCP_KEEPALIVE=80
+#NFQWS_PORTS_UDP_KEEPALIVE=
+# use <HOSTLIST> and <HOSTLIST_NOAUTO> placeholders to engage standard hostlists and autohostlist in ipset dir
+# hostlist markers are replaced to empty string if MODE_FILTER does not satisfy
+# <HOSTLIST_NOAUTO> appends ipset/zapret-hosts-auto.txt as normal list
+NFQWS_OPT="
+--filter-udp=443 --hostlist="/opt/zapret/hostlists/list-general.txt" --hostlist="/opt/zapret/hostlists/list-general-user.txt" --hostlist-exclude="/opt/zapret/hostlists/list-exclude.txt" --hostlist-exclude="/opt/zapret/hostlists/list-exclude-user.txt" --ipset-exclude="/opt/zapret/hostlists/ipset-exclude.txt" --ipset-exclude="/opt/zapret/hostlists/ipset-exclude-user.txt" --dpi-desync=fake --dpi-desync-repeats=6 --dpi-desync-fake-quic="/opt/zapret/files/fake/quic_initial_www_google_com.bin" --new
+--filter-udp=443 --hostlist="/opt/zapret/hostlists/list-google.txt" --dpi-desync=fake --dpi-desync-repeats=6 --dpi-desync-fake-quic="/opt/zapret/files/fake/quic_initial_www_google_com.bin" --new
+--filter-udp=19294-19344,50000-50100 --filter-l7=discord,stun --dpi-desync=fake --dpi-desync-fake-discord="/opt/zapret/files/fake/quic_initial_www_google_com.bin" --dpi-desync-fake-stun="/opt/zapret/files/fake/quic_initial_www_google_com.bin" --dpi-desync-repeats=6 --new
+--filter-tcp=2053,2083,2087,2096,8443 --hostlist-domains=discord.media --dpi-desync=fake --dpi-desync-repeats=6 --dpi-desync-fooling=ts --dpi-desync-fake-tls="/opt/zapret/files/fake/tls_clienthello_www_google_com.bin" --new
+--filter-tcp=443 --hostlist="/opt/zapret/hostlists/list-google.txt" --ip-id=zero --dpi-desync=fake,multisplit --dpi-desync-split-pos=1,midsld --dpi-desync-split-seqovl=681 --dpi-desync-split-seqovl-pattern="/opt/zapret/files/fake/tls_clienthello_www_google_com.bin" --dpi-desync-fooling=ts --dpi-desync-repeats=6 --dpi-desync-fake-tls="/opt/zapret/files/fake/tls_clienthello_www_google_com.bin" --new
+--filter-tcp=80,443 --hostlist="/opt/zapret/hostlists/list-general.txt" --hostlist="/opt/zapret/hostlists/list-general-user.txt" --hostlist-exclude="/opt/zapret/hostlists/list-exclude.txt" --hostlist-exclude="/opt/zapret/hostlists/list-exclude-user.txt" --ipset-exclude="/opt/zapret/hostlists/ipset-exclude.txt" --ipset-exclude="/opt/zapret/hostlists/ipset-exclude-user.txt" --dpi-desync=fake --dpi-desync-repeats=6 --dpi-desync-fooling=ts --dpi-desync-fake-tls="/opt/zapret/files/fake/stun.bin" --dpi-desync-fake-tls="/opt/zapret/files/fake/tls_clienthello_max_ru.bin" --dpi-desync-fake-http="/opt/zapret/files/fake/tls_clienthello_max_ru.bin" --new
+--filter-udp=443 --ipset="/opt/zapret/hostlists/ipset-all.txt" --hostlist-exclude="/opt/zapret/hostlists/list-exclude.txt" --hostlist-exclude="/opt/zapret/hostlists/list-exclude-user.txt" --ipset-exclude="/opt/zapret/hostlists/ipset-exclude.txt" --ipset-exclude="/opt/zapret/hostlists/ipset-exclude-user.txt" --dpi-desync=fake --dpi-desync-repeats=6 --dpi-desync-fake-quic="/opt/zapret/files/fake/quic_initial_www_google_com.bin" --new
+--filter-tcp=80,443,8443 --ipset="/opt/zapret/hostlists/ipset-all.txt" --hostlist-exclude="/opt/zapret/hostlists/list-exclude.txt" --hostlist-exclude="/opt/zapret/hostlists/list-exclude-user.txt" --ipset-exclude="/opt/zapret/hostlists/ipset-exclude.txt" --ipset-exclude="/opt/zapret/hostlists/ipset-exclude-user.txt" --dpi-desync=fake --dpi-desync-repeats=6 --dpi-desync-fooling=ts --dpi-desync-fake-tls="/opt/zapret/files/fake/stun.bin" --dpi-desync-fake-tls="/opt/zapret/files/fake/tls_clienthello_max_ru.bin" --dpi-desync-fake-http="/opt/zapret/files/fake/tls_clienthello_max_ru.bin" --new
+--filter-tcp=$GAME_FILTER_TCP --ipset="/opt/zapret/hostlists/ipset-all.txt" --ipset-exclude="/opt/zapret/hostlists/ipset-exclude.txt" --ipset-exclude="/opt/zapret/hostlists/ipset-exclude-user.txt" --dpi-desync=fake --dpi-desync-repeats=6 --dpi-desync-any-protocol=1 --dpi-desync-cutoff=n5 --dpi-desync-fooling=ts --dpi-desync-fake-tls="/opt/zapret/files/fake/stun.bin" --dpi-desync-fake-tls="/opt/zapret/files/fake/tls_clienthello_max_ru.bin" --dpi-desync-fake-http="/opt/zapret/files/fake/tls_clienthello_max_ru.bin" --new
+--filter-udp=$GAME_FILTER_UDP --ipset="/opt/zapret/hostlists/ipset-all.txt" --ipset-exclude="/opt/zapret/hostlists/ipset-exclude.txt" --ipset-exclude="/opt/zapret/hostlists/ipset-exclude-user.txt" --dpi-desync=fake --dpi-desync-repeats=12 --dpi-desync-any-protocol=1 --dpi-desync-fake-unknown-udp="/opt/zapret/files/fake/quic_initial_dbankcloud_ru.bin" --dpi-desync-cutoff=n3
+"
+
+
+# none,ipset,hostlist,autohostlist
+MODE_FILTER=none
+
+# openwrt only : donttouch,none,software,hardware
+FLOWOFFLOAD=donttouch
+
+# openwrt: specify networks to be treated as LAN. default is "lan"
+#OPENWRT_LAN="lan lan2 lan3"
+# openwrt: specify networks to be treated as WAN. default wans are interfaces with default route
+#OPENWRT_WAN4="wan vpn"
+#OPENWRT_WAN6="wan6 vpn6"
+
+# for routers based on desktop linux and macos. has no effect in openwrt.
+# CHOOSE LAN and optinally WAN/WAN6 NETWORK INTERFACES
+# or leave them commented if its not router
+# it's possible to specify multiple interfaces like this : IFACE_LAN="eth0 eth1 eth2"
+# if IFACE_WAN6 is not defined it take the value of IFACE_WAN
+#IFACE_LAN=
+#IFACE_WAN=
+#IFACE_WAN6="ipsec0 wireguard0 he_net"
+
+# should start/stop command of init scripts apply firewall rules ?
+# not applicable to openwrt with firewall3+iptables
+INIT_APPLY_FW=1
+# firewall apply hooks
+#INIT_FW_PRE_UP_HOOK="/etc/firewall.zapret.hook.pre_up"
+#INIT_FW_POST_UP_HOOK="/etc/firewall.zapret.hook.post_up"
+#INIT_FW_PRE_DOWN_HOOK="/etc/firewall.zapret.hook.pre_down"
+#INIT_FW_POST_DOWN_HOOK="/etc/firewall.zapret.hook.post_down"
+
+# do not work with ipv4
+#DISABLE_IPV4=1
+# do not work with ipv6
+DISABLE_IPV6=1
+
+# select which init script will be used to get ip or host list
+# possible values : get_user.sh get_antizapret.sh get_combined.sh get_reestr.sh get_hostlist.sh
+# comment if not required
+#GETLIST=


### PR DESCRIPTION

По сути это обычный SIMPLE_FAKE_ALT2, но с фиксами ютуба и дискорда, 
позаимствованными из ALT12. Остальные правила идентичны ALT2.

Суть:
- YouTube: чистый фейк не пробивает ютуб на МГТС  (ТСПУ пересобирает
  поток и заново проверяет SNI googlevideo). Ютуб перевёл на
  fake,multisplit с seqovl ClientHello + добавил отдельную
  QUIC-обработку для гугл листа 
- Discord: подтянул обе строки из ALT12 (войс по UDP и
  discord.media по TCP) — помогает от болячки с 5К пингом в войсе
  
  
  Буду рад , если кому-то поможет , после этого наконец-то починился ютуб (МГТС, Москва) . Буду рад любой конструктивной критике т.к я тот ещё вафля) 