### PR TITLE
nix: refactor flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Ignore NixOS files
-flake.lock
 result
+flake.lock
 
 # Other ignore
 hostlists/.game_filter.enabled

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,6 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
     zapret-flowseal = {
       url = "github:Flowseal/zapret-discord-youtube";
       flake = false;
@@ -14,27 +13,25 @@
     inputs@{
       self,
       nixpkgs,
-      flake-utils,
       zapret-flowseal,
       ...
     }:
-    flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-      in
-      {
-        packages = {
-          zapret = pkgs.callPackage ./nixos/package.nix {
-            inherit
-              zapret-flowseal
-              ;
-          };
-          default = self.packages.${system}.zapret;
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forAllSystems (pkgs: rec {
+        zapret = pkgs.callPackage ./nixos/package.nix {
+          inherit zapret-flowseal;
         };
-      }
-    )
-    // {
+        default = zapret;
+      });
+
       nixosModules = {
         zapret-discord-youtube = import ./nixos/module.nix inputs;
         withTestTools =


### PR DESCRIPTION
Немного улучшил опыт для пользователей NixOS.
Убрал flake-utils так как это излишняя зависимость, все что она делает можно сделать подручными средствами языка
Также убрал из gitignore flake.lock так как этот файл необходим для пина зависимостей, что бы у всех пользователей были запинены зависимости. В долгосроке отсутствие запиненных зависимостей вызовет ошибки из-за обновления любого из инпутов.

@kartavkun 